### PR TITLE
Fix context type mismatch

### DIFF
--- a/context/context.tsx
+++ b/context/context.tsx
@@ -86,7 +86,7 @@ interface ChatbotUIContext {
   chatMessages: ChatMessage[]
   setChatMessages: Dispatch<SetStateAction<ChatMessage[]>>
   chatSettings: ChatSettings | null
-  setChatSettings: Dispatch<SetStateAction<ChatSettings>>
+  setChatSettings: Dispatch<SetStateAction<ChatSettings | null>>
   selectedChat: Tables<"chats"> | null
   setSelectedChat: Dispatch<SetStateAction<Tables<"chats"> | null>>
   chatFileItems: Tables<"file_items">[]


### PR DESCRIPTION
## Summary
- align `setChatSettings` type with nullable `chatSettings` state

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc74a5d24832c98cbd95c075b016c